### PR TITLE
Update to basin3d version 0.5.0; fix error in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Coming soon
 ## Development Practices
 * django-basin3d uses the [GitFlow model](https://datasift.github.io/gitflow/IntroducingGitFlow.html) 
   of branching and code versioning in git. 
-* Code development will be peformed in a forked copy of the repo. Commits will not be made directly to the django-basin3d repo.  Developers will submit a pull request that is then merged by another team member, if another team member is available.
+* Code development will be performed in a forked copy of the repo. Commits will not be made directly to the django-basin3d repo.  Developers will submit a pull request that is then merged by another team member, if another team member is available.
 * Each pull request should contain only related modifications to a feature or bug fix.  
 * Sensitive information (secret keys, usernames etc) and configuration data (e.g database host port) should not be checked in to the repo.
 * A practice of rebasing with the main repo should be used rather that merge commmits.  
@@ -16,7 +16,7 @@ Coming soon
 These instructions will get you a copy of the project up and running on your local machine for 
 development and testing purposes. 
 
-    $ git clone git@bitbucket.org:BASIN-3D/django-basin3d.git
+    $ git clone git@github.com:BASIN-3D/django-basin3d.git
     $ cd django-basin3d
 
 ## Develop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = '>=3.8,<3.11'
 dependencies = [
-    'basin3d==0.4.3',
+    'basin3d==0.5.0',
     'django>=4.0',
     'djangorestframework',
     'django-filter',


### PR DESCRIPTION
Closes #53, #54

Note: did not add EPA plugin to the example-django example project