### PR TITLE
Update basin3d version and GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = '>=3.8,<3.11'
 dependencies = [
-    'basin3d==1.1.2',
+    'basin3d==1.2.0',
     'django==4.0',
     'djangorestframework',
     'django-filter',


### PR DESCRIPTION
Update basin3d to latest version 1.2.0
Update Github actions workflow main to use latest ubuntu.

Closes #73, #77